### PR TITLE
Add a function to automate the `--help`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ typedef struct {
   char *name;                   /* name of the parameter                */
   cfg_dtype_t dtype;            /* data type of the parameter           */
   void *var;                    /* variable for the retrieved value     */
+  char *help;                   /* help message for the parameter       */
 } cfg_param_t;
 ```
 
@@ -69,7 +70,8 @@ The format of the attributes are:
 -   `lopt`: a string composed of characters with graphical representations (ensured by [isgraph](https://en.cppreference.com/w/c/string/byte/isgraph)), or a `NULL` pointer;
 -   `name`: a string composed of case-sensitive letters, digits, and the underscore character, and starting with either a letter or an underscore;
 -   `dtype`: a pre-defined data type indicator;
--   `var`: pointer to the address of the variable/array for holding the retrieved value, and no memory allocation is needed.
+-   `var`: pointer to the address of the variable/array for holding the retrieved value, and no memory allocation is needed;
+-   `help`: a string defining the help message for the parameter.
 
 In particular, if `opt` is set to `0`, or `lopt` is set to `NULL`, the value will not be retrieved from short or long command line options, respectively. For safety consideration, the length of `lopt` and `name` must be smaller than the pre-defined [`CFG_MAX_LOPT_LEN`](libcfg.h#L66) and [`CFG_MAX_NAME_LEN`](libcfg.h#L65) values respectively.
 
@@ -120,10 +122,11 @@ typedef struct {
   char *lopt;                   /* long command line option             */
   void (*func) (void *);        /* pointer to the function              */
   void *args;                   /* pointer to the arguments             */
+  char *help;                   /* help message for the function        */
 } cfg_func_t;
 ```
 
-The `opt` and `lopt` variables are the short and long command line option for calling this function, respectively. And at least one of them has to be set, i.e., a case-sensitive letter for `opt`, or a string composed of graphical characters for `lopt`. Again, the length of `lopt` must be smaller than the pre-defined [`CFG_MAX_LOPT_LEN`](libcfg.h#L66) limit. The pointers `func` and `args` are the address of the function to be called, and the corresponding arguments, respectively.
+The `opt` and `lopt` variables are the short and long command line option for calling this function, respectively. And at least one of them has to be set, i.e., a case-sensitive letter for `opt`, or a string composed of graphical characters for `lopt`. Again, the length of `lopt` must be smaller than the pre-defined [`CFG_MAX_LOPT_LEN`](libcfg.h#L66) limit. The pointers `func` and `args` are the address of the function to be called, and the corresponding arguments, respectively. `help` is a string defining the help message for the function.
 
 The functions can then be registered using
 
@@ -138,13 +141,15 @@ Note that the `cfg_func_t` type structure for function registration cannot be de
 As an example, a typical demand for calling functions via command line is to print the usage of a program, when there is the `-h` or `--help` flag. In this case, the help function and the corresponding structure can be defined as
 
 ```c
-void help(void *arg) {
-  printf("Display the help messages.\n");
+void help(void *cfg) {
+  cfg_print_help((cfg_t *)cfg);
   exit(0);
 }
 ```
 ```c
-const cfg_func_t help_func = {'h', "help", help, NULL};
+cfg_t *cfg = init_config();
+...
+const cfg_func_t help_func = {'h', "help", help, cfg, "Print this message and exit."};
 ```
 
 <sub>[\[TOC\]](#table-of-contents)</sub>

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -std=c99 -O2 -Wall
+CFLAGS = -std=c99 -O0 -ggdb -Wall -Werror
 EXEC = libcfg_example
 
 all:

--- a/example/example.c
+++ b/example/example.c
@@ -45,33 +45,14 @@
 }
 
 /* A function that prints help messages. */
-void help(void *pname) {
-  printf("Usage: %s [OPTION [VALUE]]\n\
-  -c, --conf\n\
-        Set the configuration file.\n\
-  -b, --bool / -B, --bools\n\
-        Set the boolean type BOOL / BOOL_ARR.\n\
-  -a, --char / -A, --chars\n\
-        Set the char type CHAR / CHAR_ARR.\n\
-  -i, --int / -I, --ints\n\
-        Set the int type INT / INT_ARR.\n\
-  -l, --long / -L, --longs\n\
-        Set the long type LONG / LONG_ARR.\n\
-  -f, --float / -F, --floats\n\
-        Set the float type FLOAT / FLOAT_ARR.\n\
-  -d, --double / -D, --doubles\n\
-        Set the double type DOUBLE / DOUBLE_ARR.\n\
-  -s, --string / -S, --strings\n\
-        Set the string type STRING / STRING_ARR.\n\
-  -h, --help\n\
-        Display this message and exit.\n\
-  --license\n\
-        Display the license information.\n", (char *) pname);
+void help(void *cfg) {
+  cfg_print_help((cfg_t *)cfg);
   exit(0);
 }
 
 /* A function that prints the license information. */
 void license(void *arg) {
+  (void) arg; // unused
   printf("This code is distributed under the MIT license.\n\
 See https://github.com/cheng-zhao/libcfg/blob/master/LICENSE.txt\n");
   exit(0);
@@ -97,47 +78,78 @@ int main(int argc, char *argv[]) {
   float *aflt;
   double *adbl;
   char **astr;
+  cfg_t *cfg = cfg_init();
 
   /* Configurations for functions to be called via command line flags. */
   const int nfunc = 2;
   const cfg_func_t funcs[2] = {
-    {   'h',    "help",         help,           argv[0] },
-    {   0,      "license",      license,        NULL    }
+    { 'h', "help", help, cfg, "Print this message and exit." },
+    { 0, "license", license, NULL , NULL }
   };
 
   /* Configuration parameters. */
-  const int npar = 15;
-  const cfg_param_t params[15] = {
-    {   'c',    "conf",         "CONF_FILE",    CFG_DTYPE_STR,  &fconf  },
-    {   'b',    "bool",         "BOOL",         CFG_DTYPE_BOOL, &vbool  },
-    {   'a',    "char",         "CHAR",         CFG_DTYPE_CHAR, &vchar  },
-    {   'i',    "int",          "INT",          CFG_DTYPE_INT,  &vint   },
-    {   'l',    "long",         "LONG",         CFG_DTYPE_LONG, &vlong  },
-    {   'f',    "float",        "FLOAT",        CFG_DTYPE_FLT,  &vflt   },
-    {   'd',    "double",       "DOUBLE",       CFG_DTYPE_DBL,  &vdbl   },
-    {   's',    "string",       "STRING",       CFG_DTYPE_STR,  &vstr   },
-    {   'B',    "bools",        "BOOL_ARR",     CFG_ARRAY_BOOL, &abool  },
-    {   'A',    "chars",        "CHAR_ARR",     CFG_ARRAY_CHAR, &achar  },
-    {   'I',    "ints",         "INT_ARR",      CFG_ARRAY_INT,  &aint   },
-    {   'L',    "longs",        "LONG_ARR",     CFG_ARRAY_LONG, &along  },
-    {   'F',    "floats",       "FLOAT_ARR",    CFG_ARRAY_FLT,  &aflt   },
-    {   'D',    "doubles",      "DOUBLE_ARR",   CFG_ARRAY_DBL,  &adbl   },
-    {   'S',    "strings",      "STRING_ARR",   CFG_ARRAY_STR,  &astr   }
+  const cfg_param_t params[] = {
+    { 'c', "conf", "CONF_FILE", CFG_DTYPE_STR, &fconf,
+        "Set the configuration file."
+    },
+    { 'b', "bool", "BOOL", CFG_DTYPE_BOOL, &vbool,
+        "Set the boolean type BOOL."
+    },
+    { 'a', "char", "CHAR", CFG_DTYPE_CHAR, &vchar,
+        "Set the char type CHAR."
+    },
+    { 'i', "int", "INT", CFG_DTYPE_INT, &vint,
+        "Set the int type INT."
+    },
+    { 'l', "long", "LONG", CFG_DTYPE_LONG, &vlong,
+        "Set the long type LONG"
+    },
+    { 'f', "float", "FLOAT", CFG_DTYPE_FLT, &vflt,
+        "Set the float type FLOAT"
+    },
+    { 'd', "double", "DOUBLE", CFG_DTYPE_DBL, &vdbl,
+        "Set the double type DOUBLE"
+    },
+    { 's', "string", "STRING", CFG_DTYPE_STR, &vstr,
+        "Set the string type STRING"
+    },
+    { 'B', "bools", "BOOL_ARR", CFG_ARRAY_BOOL, &abool,
+        "Set the boolean type BOOL_ARR"
+    },
+    { 'A', "chars", "CHAR_ARR", CFG_ARRAY_CHAR, &achar,
+        "Set the char type CHAR_ARR"
+    },
+    { 'I', "ints", "INT_ARR", CFG_ARRAY_INT, &aint,
+        "Set the int type INT_ARR"
+    },
+    { 'L', "longs", "LONG_ARR", CFG_ARRAY_LONG, &along,
+        "Set the long type LONG_ARR"
+    },
+    { 'F', "floats", "FLOAT_ARR", CFG_ARRAY_FLT, &aflt,
+        "Set the float type FLOAT_ARR"
+    },
+    { 'D', "doubles", "DOUBLE_ARR", CFG_ARRAY_DBL, &adbl,
+        "Set the double type DOUBLE_ARR"
+    },
+    { 'S', "strings", "STRING_ARR", CFG_ARRAY_STR, &astr,
+        "Set the string type STRING_ARR"
+    }
   };
+  const int npar = sizeof(params) / sizeof(params[0]);
+  (void) npar;
 
   /* Initialise the configuations. */
-  cfg_t *cfg = cfg_init();
   if (!cfg) {
     fprintf(stderr, "Error: failed to initlise the configurations.\n");
     return 1;
   }
 
-  /* Register functions to be called via command line options. */
-  if (cfg_set_funcs(cfg, funcs, nfunc)) PRINT_ERROR;
-  PRINT_WARNING;
-
   /* Register configuration parameters. */
   if (cfg_set_params(cfg, params, npar)) PRINT_ERROR;
+  PRINT_WARNING;
+
+  /* Register functions to be called via command line options. */
+  if (cfg_set_funcs(cfg, funcs, nfunc)) PRINT_ERROR;
   PRINT_WARNING;
 
   /* Parse command line options. */

--- a/example/example.c
+++ b/example/example.c
@@ -46,6 +46,7 @@
 
 /* A function that prints help messages. */
 void help(void *cfg) {
+  cfg_print_usage((cfg_t *)cfg, NULL);
   cfg_print_help((cfg_t *)cfg);
   exit(0);
 }

--- a/libcfg.c
+++ b/libcfg.c
@@ -359,6 +359,35 @@ void cfg_print_help(cfg_t *cfg) {
 }
 
 /******************************************************************************
+Function `cfg_print_usage`:
+  Print usage messages based on validated parameters and provided progname
+Arguments:
+  * `cfg`:      entry for all configuration parameters;
+  * `progname`: program name to be displayed
+******************************************************************************/
+void cfg_print_usage(cfg_t *cfg, char *progname) {
+  if (cfg && !CFG_IS_ERROR(cfg)) {
+    char options[] = " [OPTIONS]";
+    char functions[] = " [FUNCTIONS]";
+    const char local_progname[] = "program";
+    if (!progname || *progname == '\0') {
+      progname = (char *)local_progname;
+    }
+    if (cfg->npar == 1) {
+      options[8] = ']'; options[9] = '\0'; }  // Singularize
+    else if (cfg->npar == 0)
+      *options = '\0'; // Remove options
+    if (cfg->nfunc == 1) {
+      functions[10] = ']';
+      functions[11] = '\0';
+    }  // Singularize
+    else if (cfg->nfunc == 0)
+      *functions = '\0'; // Remove functions
+    printf("Usage: %s%s%s\n", progname, options, functions);
+  }
+}
+
+/******************************************************************************
 Function `cfg_set_params`:
   Verify and register configuration parameters.
 Arguments:

--- a/libcfg.h
+++ b/libcfg.h
@@ -234,6 +234,7 @@ Arguments:
   * `cfg`:      entry for all configuration parameters;
 ******************************************************************************/
 void cfg_print_help(cfg_t *cfg);
+void cfg_print_usage(cfg_t *cfg, char *progname);
 
 /******************************************************************************
 Function `cfg_print_usage`:

--- a/libcfg.h
+++ b/libcfg.h
@@ -7,17 +7,17 @@
         https://github.com/cheng-zhao/libcfg
 
 * Copyright (c) 2019 Cheng Zhao <zhaocheng03@gmail.com>
- 
+
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
  in the Software without restriction, including without limitation the rights
  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  copies of the Software, and to permit persons to whom the Software is
  furnished to do so, subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all
  copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -64,6 +64,7 @@ typedef enum {
 \*============================================================================*/
 #define CFG_MAX_NAME_LEN        128
 #define CFG_MAX_LOPT_LEN        128
+#define CFG_MAX_HELP_LEN        1024
 #define CFG_MAX_FILENAME_LEN    1024
 
 /*============================================================================*\
@@ -100,6 +101,7 @@ typedef struct {
   char *name;                   /* name of the parameter                */
   cfg_dtype_t dtype;            /* data type of the parameter           */
   void *var;                    /* variable for the retrieved value     */
+  char *help;                   /* help message                         */
 } cfg_param_t;
 
 /* Interface for registering command line functions. */
@@ -108,6 +110,7 @@ typedef struct {
   char *lopt;                   /* long command line option             */
   void (*func) (void *);        /* pointer to the function              */
   void *args;                   /* pointer to the arguments             */
+  char *help;                   /* help message                         */
 } cfg_func_t;
 
 
@@ -223,5 +226,22 @@ Arguments:
   * `msg`:      string to be printed before the error message.
 ******************************************************************************/
 void cfg_pwarn(cfg_t *cfg, FILE *fp, const char *msg);
+
+/******************************************************************************
+Function `cfg_print_help`:
+  Print help messages based on validated parameters
+Arguments:
+  * `cfg`:      entry for all configuration parameters;
+******************************************************************************/
+void cfg_print_help(cfg_t *cfg);
+
+/******************************************************************************
+Function `cfg_print_usage`:
+  Print usage messages based on validated parameters and provided progname
+Arguments:
+  * `cfg`:      entry for all configuration parameters;
+  * `progname`: program name to be displayed
+******************************************************************************/
+void cfg_print_usage(cfg_t *cfg, char *progname);
 
 #endif


### PR DESCRIPTION
This PR is about to provide a `--help` automation based on the user configuration definition.

It bases its content on validated parameters and functions names to avoid duplication.